### PR TITLE
Update openconfig-mpls-te.yang

### DIFF
--- a/release/models/mpls/openconfig-mpls-te.yang
+++ b/release/models/mpls/openconfig-mpls-te.yang
@@ -792,6 +792,11 @@ submodule openconfig-mpls-te {
       description
         "P2P tunnel destination address";
     }
+    leaf record-record-enabled {
+      type Boolean;
+      description
+        "Enables recording a path on an LSP using the record route object (RRO)";
+    }
   }
 
   grouping p2p-path-state {


### PR DESCRIPTION
Adding leaf record-record-enabled under grouping tunnel-p2p-attributes-config as the conclusion of the discussion happened [here](https://github.com/openconfig/public/issues/889), adding 